### PR TITLE
Add joints in 2D and 3D

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -30,6 +30,8 @@ fn setup(
     let icon = asset_server.load("assets/icon.png").unwrap();
     let plat = asset_server.load("assets/platform.png").unwrap();
     let square = asset_server.load("assets/square.png").unwrap();
+    let mut anchor = None;
+    let mut target = None;
     commands
         .spawn(Camera2dComponents::default())
         .spawn(SpriteComponents {
@@ -47,6 +49,7 @@ fn setup(
         .with_children(|parent| {
             parent.spawn((Shape::from(Size::new(28.0, 28.0)),));
         })
+        .for_current_entity(|e| anchor = Some(e))
         .spawn(SpriteComponents {
             material: materials.add(plat.into()),
             ..Default::default()
@@ -131,7 +134,23 @@ fn setup(
         )
         .with_children(|parent| {
             parent.spawn((Shape::from(Size::new(20.0, 20.0)),));
-        });
+        })
+        .spawn(SpriteComponents {
+            material: materials.add(square.into()),
+            ..Default::default()
+        })
+        .with(
+            RigidBody::new(Mass::Real(1.0))
+                .with_status(Status::Semikinematic)
+                .with_position(Vec2::new(100.0, 100.0)),
+        )
+        .with_children(|parent| {
+            parent.spawn((Shape::from(Size::new(20.0, 20.0)),));
+        })
+        .for_current_entity(|e| target = Some(e))
+        .spawn((
+            SpringJoint::new(anchor.unwrap(), target.unwrap()).with_offset(Vec2::new(30.0, 30.0)),
+        ));
 }
 
 #[derive(Default)]

--- a/examples/simple3d.rs
+++ b/examples/simple3d.rs
@@ -39,6 +39,8 @@ fn setup(
     let bigcube = meshes.add(shape::Cube { size: 8.0 }.into());
     let smallcube = meshes.add(shape::Cube { size: 0.2 }.into());
     let mut camera = None;
+    let mut anchor = None;
+    let mut target = None;
     commands
         .spawn(LightComponents {
             transform: Transform::from_translation(Vec3::new(0.0, 5.0, 5.0)),
@@ -71,6 +73,24 @@ fn setup(
         .with_children(|parent| {
             parent.spawn((Shape::from(Size3::new(1.0, 1.0, 1.0)),));
         })
+        .for_current_entity(|e| anchor = Some(e))
+        .spawn(PbrComponents {
+            mesh: smallcube,
+            material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
+            ..Default::default()
+        })
+        .with(
+            RigidBody::new(Mass::Real(0.5))
+                .with_status(Status::Semikinematic)
+                .with_position(Vec3::new(10.0, 10.0, 10.0)),
+        )
+        .with_children(|parent| {
+            parent.spawn((Shape::from(Size3::new(0.2, 0.2, 0.2)),));
+        })
+        .for_current_entity(|e| target = Some(e))
+        .spawn((SpringJoint::new(anchor.unwrap(), target.unwrap())
+            .with_rigidness(0.5)
+            .with_offset(Vec3::new(2.0, 2.0, 0.0)),))
         .spawn(PbrComponents {
             mesh: cube,
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),

--- a/src/dim2.rs
+++ b/src/dim2.rs
@@ -20,10 +20,12 @@ pub mod stage {
     #[doc(hidden)]
     pub use bevy::prelude::stage::*;
 
+    pub const COLLIDING_JOINT: &str = "colliding_joint";
     pub const PHYSICS_STEP: &str = "physics_step";
     pub const BROAD_PHASE: &str = "broad_phase";
     pub const NARROW_PHASE: &str = "narrow_phase";
     pub const PHYSICS_SOLVE: &str = "physics_solve";
+    pub const RIGID_JOINT: &str = "rigid_joint";
     pub const SYNC_TRANSFORM: &str = "sync_transform";
 }
 
@@ -38,17 +40,31 @@ impl Plugin for Physics2dPlugin {
             .add_resource(AngularTolerance::default())
             .add_event::<Manifold>()
             .add_stage_before(stage::UPDATE, stage::PHYSICS_STEP)
+            .add_stage_before(stage::PHYSICS_STEP, stage::COLLIDING_JOINT)
             .add_stage_after(stage::PHYSICS_STEP, stage::BROAD_PHASE)
             .add_stage_after(stage::BROAD_PHASE, stage::NARROW_PHASE)
             .add_stage_after(stage::NARROW_PHASE, stage::PHYSICS_SOLVE)
-            .add_stage_after(stage::PHYSICS_SOLVE, stage::SYNC_TRANSFORM);
+            .add_stage_after(stage::PHYSICS_SOLVE, stage::RIGID_JOINT)
+            .add_stage_after(stage::RIGID_JOINT, stage::SYNC_TRANSFORM);
         let physics_step = PhysicsStep::default().system(app.resources_mut());
         app.add_system_to_stage(stage::PHYSICS_STEP, physics_step)
             .add_system_to_stage(stage::BROAD_PHASE, broad_phase_system.system())
             .add_system_to_stage(stage::NARROW_PHASE, narrow_phase_system.system());
         let solver = Solver::default().system(app.resources_mut());
         app.add_system_to_stage(stage::PHYSICS_SOLVE, solver)
-            .add_system_to_stage(stage::SYNC_TRANSFORM, sync_transform_system.system());
+            .add_system_to_stage(stage::SYNC_TRANSFORM, sync_transform_system.system())
+            .add_system_to_stage(
+                FixedJointBehaviour::STAGE,
+                joint_system::<FixedJointBehaviour>.system(),
+            )
+            .add_system_to_stage(
+                MechanicalJointBehaviour::STAGE,
+                joint_system::<MechanicalJointBehaviour>.system(),
+            )
+            .add_system_to_stage(
+                SpringJointBehaviour::STAGE,
+                joint_system::<SpringJointBehaviour>.system(),
+            );
     }
 }
 
@@ -224,14 +240,14 @@ impl From<Size> for Shape {
 
 #[doc(hidden)]
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Joint {
+pub struct InnerJoint {
     body1: Entity,
     body2: Entity,
     offset: Vec2,
     angle: f32,
 }
 
-impl Joint {
+impl InnerJoint {
     pub fn new(body1: Entity, body2: Entity) -> Self {
         Self {
             body1,
@@ -252,11 +268,260 @@ impl Joint {
     }
 }
 
-#[doc(hidden)]
-#[derive(Default, Debug, Clone, Copy)]
-pub struct Solved {
-    fst: bool,
-    snd: bool,
+/// Defines a set of behaviours on how joints should move the anchored body relative to the anchor.
+pub trait JointBehaviour: Send + Sync + 'static {
+    const STAGE: &'static str = stage::COLLIDING_JOINT;
+
+    /// Returns a new position for target based on `self` and `anchor`.
+    fn position(
+        &mut self,
+        _offset: Vec2,
+        _anchor: &RigidBody,
+        _target: &RigidBody,
+    ) -> Option<Vec2> {
+        None
+    }
+
+    /// Returns a new rotation for target based on `self` and `anchor`.
+    fn rotation(&mut self, _angle: f32, _anchor: &RigidBody, _target: &RigidBody) -> Option<f32> {
+        None
+    }
+
+    /// Returns a new linear velocity for target based on `self` and `anchor`.
+    fn linear_velocity(
+        &mut self,
+        _offset: Vec2,
+        _anchor: &RigidBody,
+        _target: &RigidBody,
+    ) -> Option<Vec2> {
+        None
+    }
+
+    /// Returns a new angular velocity for target based on `self` and `anchor`.
+    fn angular_velocity(
+        &mut self,
+        _angle: f32,
+        _anchor: &RigidBody,
+        _target: &RigidBody,
+    ) -> Option<f32> {
+        None
+    }
+
+    /// Returns a linear impulse to apply to target based on `self` and `anchor`.
+    fn linear_impulse(
+        &mut self,
+        _offset: Vec2,
+        _anchor: &RigidBody,
+        _target: &RigidBody,
+    ) -> Option<Vec2> {
+        None
+    }
+
+    /// Returns an angular impulse to apply to target based on `self` and `anchor`.
+    fn angular_impulse(
+        &mut self,
+        _angle: f32,
+        _anchor: &RigidBody,
+        _target: &RigidBody,
+    ) -> Option<f32> {
+        None
+    }
+}
+
+/// A joint behaviour that causes the anchored body to be rigidly fixed at an offset and an angle.
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct FixedJointBehaviour;
+
+impl JointBehaviour for FixedJointBehaviour {
+    const STAGE: &'static str = stage::RIGID_JOINT;
+
+    fn position(&mut self, offset: Vec2, anchor: &RigidBody, _target: &RigidBody) -> Option<Vec2> {
+        Some(anchor.position + offset)
+    }
+
+    fn rotation(&mut self, angle: f32, anchor: &RigidBody, _target: &RigidBody) -> Option<f32> {
+        Some(anchor.rotation + angle)
+    }
+}
+
+/// A joint behaviour that causes the anchored body to be accurately positioned with an offset and an angle.
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct MechanicalJointBehaviour;
+
+impl JointBehaviour for MechanicalJointBehaviour {
+    const STAGE: &'static str = stage::COLLIDING_JOINT;
+
+    fn position(&mut self, offset: Vec2, anchor: &RigidBody, _target: &RigidBody) -> Option<Vec2> {
+        Some(anchor.position + offset)
+    }
+
+    fn rotation(&mut self, angle: f32, anchor: &RigidBody, _target: &RigidBody) -> Option<f32> {
+        Some(anchor.rotation + angle)
+    }
+
+    fn linear_velocity(
+        &mut self,
+        _offset: Vec2,
+        _anchor: &RigidBody,
+        _target: &RigidBody,
+    ) -> Option<Vec2> {
+        Some(Vec2::zero())
+    }
+
+    fn angular_velocity(
+        &mut self,
+        _angle: f32,
+        _anchor: &RigidBody,
+        _target: &RigidBody,
+    ) -> Option<f32> {
+        Some(0.0)
+    }
+}
+
+/// A joint behaviour that will move the anchored body into a position and angle relative to the anchor over time.
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct SpringJointBehaviour {
+    rigidness: f32,
+}
+
+impl SpringJointBehaviour {
+    /// Create a new SpringJointBehaviour with an exact rigidness value.
+    ///
+    /// Rigidness describes how "snappy" the spring joint is. When it's at 0.0,
+    /// the anchored body will "jump" into position softly over one second.
+    /// When it's at 1.0, the anchored body will "jump" into position almost instantaenously.
+    pub fn new(rigidness: f32) -> Option<SpringJointBehaviour> {
+        if rigidness < 0.0 || rigidness >= 1.0 {
+            None
+        } else {
+            Some(Self { rigidness })
+        }
+    }
+
+    pub fn new_lossy(rigidness: f32) -> SpringJointBehaviour {
+        Self {
+            rigidness: rigidness.max(0.0).min(1.0),
+        }
+    }
+}
+
+impl JointBehaviour for SpringJointBehaviour {
+    const STAGE: &'static str = stage::COLLIDING_JOINT;
+
+    fn linear_velocity(
+        &mut self,
+        _offset: Vec2,
+        _anchor: &RigidBody,
+        _target: &RigidBody,
+    ) -> Option<Vec2> {
+        Some(Vec2::zero())
+    }
+
+    fn angular_velocity(
+        &mut self,
+        _angle: f32,
+        _anchor: &RigidBody,
+        _target: &RigidBody,
+    ) -> Option<f32> {
+        Some(0.0)
+    }
+
+    fn linear_impulse(
+        &mut self,
+        offset: Vec2,
+        anchor: &RigidBody,
+        target: &RigidBody,
+    ) -> Option<Vec2> {
+        // the minimum time to "jump" into position
+        const EPSILON: f32 = 0.1;
+        // the maximum time to "jump" into position
+        const T: f32 = 1.0;
+        let springiness = 1.0 - self.rigidness;
+        let position = anchor.position + offset;
+        let d = position - target.position;
+        let scale = (T - EPSILON) * springiness + EPSILON;
+        let impulse = d * target.mass / scale;
+        Some(impulse)
+    }
+
+    fn angular_impulse(
+        &mut self,
+        angle: f32,
+        anchor: &RigidBody,
+        target: &RigidBody,
+    ) -> Option<f32> {
+        // the minimum time to "jump" into position
+        const EPSILON: f32 = 0.1;
+        // the maximum time to "jump" into position
+        const T: f32 = 1.0;
+        let springiness = 1.0 - self.rigidness;
+        let rotation = anchor.rotation + angle;
+        let d = rotation - target.rotation;
+        let scale = (T - EPSILON) * springiness + EPSILON;
+        let impulse = d * target.mass / scale;
+        Some(impulse)
+    }
+}
+
+/// Allows one `RigidBody` to be anchored at another one
+/// in a fixed way, along with a local offset and angle.
+pub type FixedJoint = Joint<FixedJointBehaviour>;
+
+/// Allows one `RigidBody` to be anchored at another one
+/// in a physically accurate way, along with a local offset and angle.
+pub type MechanicalJoint = Joint<MechanicalJointBehaviour>;
+
+/// Allows one `RigidBody` to be anchored at another one
+/// in a spring-y way, along with a local offset and angle.
+pub type SpringJoint = Joint<SpringJointBehaviour>;
+
+impl SpringJoint {
+    /// Add a rigidness value to an owned `Joint`.
+    pub fn with_rigidness(mut self, rigidness: f32) -> Self {
+        self.behaviour.rigidness = rigidness;
+        self
+    }
+}
+
+/// Allows one `RigidBody` to be anchored at another one
+/// in a pre-defined way, along with a local offset and angle.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Joint<B> {
+    inner: InnerJoint,
+    behaviour: B,
+}
+
+impl<B: JointBehaviour + Default> Joint<B> {
+    /// Create a new joint, where the second body shall be anchored at the first body.
+    pub fn new(body1: Entity, body2: Entity) -> Self {
+        Self::with_behaviour(body1, body2, B::default())
+    }
+}
+
+impl<B: JointBehaviour> Joint<B> {
+    /// Create a new joint, where the second body shall be anchored at the first body.
+    pub fn with_behaviour(body1: Entity, body2: Entity, behaviour: B) -> Self {
+        Self {
+            inner: InnerJoint::new(body1, body2),
+            behaviour,
+        }
+    }
+
+    /// Add an offset to an owned `Joint`.
+    pub fn with_offset(self, offset: Vec2) -> Self {
+        Self {
+            inner: self.inner.with_offset(offset),
+            behaviour: self.behaviour,
+        }
+    }
+
+    /// Add an angle to an owned `Joint`.
+    pub fn with_angle(self, angle: f32) -> Self {
+        Self {
+            inner: self.inner.with_angle(angle),
+            behaviour: self.behaviour,
+        }
+    }
 }
 
 /// The rigid body.
@@ -293,7 +558,6 @@ pub struct RigidBody {
     inv_mass: f32,
     active: bool,
     sensor: bool,
-    solved: Solved,
 }
 
 impl RigidBody {
@@ -316,7 +580,6 @@ impl RigidBody {
             inv_mass: mass.inverse(),
             active: true,
             sensor: false,
-            solved: Default::default(),
         }
     }
 
@@ -975,6 +1238,64 @@ fn physics_step_system(
                 }
                 body.lowest_position = position + lowest_point / count as f32;
             }
+        }
+    }
+}
+
+pub fn joint_system<B: JointBehaviour>(
+    mut commands: Commands,
+    mut query: Query<(Entity, Mut<Joint<B>>)>,
+    bodies: Query<Mut<RigidBody>>,
+) {
+    for (e, mut joint) in &mut query.iter() {
+        let anchor = if let Ok(anchor) = bodies.get::<RigidBody>(joint.inner.body1) {
+            anchor
+        } else {
+            commands.despawn_recursive(e);
+            continue;
+        };
+        let target = if let Ok(target) = bodies.get::<RigidBody>(joint.inner.body2) {
+            target
+        } else {
+            commands.despawn_recursive(e);
+            continue;
+        };
+        let offset = joint.inner.offset;
+        let angle = joint.inner.angle;
+        let position = joint.behaviour.position(offset, &anchor, &target);
+        let rotation = joint.behaviour.rotation(angle, &anchor, &target);
+        let linvel = joint.behaviour.linear_velocity(offset, &anchor, &target);
+        let angvel = joint.behaviour.angular_velocity(angle, &anchor, &target);
+        let linimp = joint.behaviour.linear_impulse(offset, &anchor, &target);
+        let angimp = joint.behaviour.angular_impulse(angle, &anchor, &target);
+
+        mem::drop(anchor);
+        mem::drop(target);
+
+        let mut target = bodies.get_mut::<RigidBody>(joint.inner.body2).unwrap();
+
+        if let Some(position) = position {
+            target.position = position;
+        }
+
+        if let Some(rotation) = rotation {
+            target.rotation = rotation;
+        }
+
+        if let Some(linvel) = linvel {
+            target.linvel = linvel;
+        }
+
+        if let Some(angvel) = angvel {
+            target.angvel = angvel;
+        }
+
+        if let Some(linimp) = linimp {
+            target.apply_linear_impulse(linimp);
+        }
+
+        if let Some(angimp) = angimp {
+            target.apply_angular_impulse(angimp);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,10 @@ pub mod prelude2d {
     //! simulation.
     pub use crate::common::{GlobalFriction, Mass, Status};
     pub use crate::dim2::{
-        AngularTolerance, BroadPhase, GlobalGravity, GlobalStep, GlobalUp, Joint, Manifold,
-        Physics2dPlugin, RigidBody, RotationMode, Shape, TranslationMode,
+        AngularTolerance, BroadPhase, FixedJoint, FixedJointBehaviour, GlobalGravity, GlobalStep,
+        GlobalUp, JointBehaviour, Manifold, MechanicalJoint, MechanicalJointBehaviour,
+        Physics2dPlugin, RigidBody, RotationMode, Shape, SpringJoint, SpringJointBehaviour,
+        TranslationMode,
     };
 }
 
@@ -109,7 +111,9 @@ pub mod prelude3d {
     //! simulation.
     pub use crate::common::{GlobalFriction, Mass, Status, Vec3Ext};
     pub use crate::dim3::{
-        AngularTolerance, BroadPhase, GlobalGravity, GlobalStep, GlobalUp, Joint, Manifold,
-        Physics3dPlugin, RigidBody, Shape, Size3, Up, UpRotation,
+        AngularTolerance, BroadPhase, FixedJoint, FixedJointBehaviour, GlobalGravity, GlobalStep,
+        GlobalUp, Joint, JointBehaviour, Manifold, MechanicalJoint, MechanicalJointBehaviour,
+        Physics3dPlugin, RigidBody, Shape, Size3, SpringJoint, SpringJointBehaviour, Up,
+        UpRotation,
     };
 }


### PR DESCRIPTION
Closes #1.

This commit includes three types of joints that work in both 2d and
3d.

- `FixedJoint` is the simplest joint. It simply locks the target body
   at the anchor with an offset and an angle without considering other
   geometry (ignoring collisions).
- `MechanicalJoint` is like a `FixedJoint`, but it does consider other
   geometry (allows the target body to be displaced by collisions).
- `SpringJoint` will "jump" the target body to its target position
   over time. This time can be controlled by the `rigidness` value.
   A rigidness of 0.0 means high springiness, where the time it
   takes for the target body to go into position is some high
   unspecified number. A rigidness of 1.0 means low springiness,
   where  the time it the target body to go into position is some low
   number,  but bigger than `0.0` or even `f32::EPSILON` (it may or
   may not be 100ms).