### PR TITLE
fix compile errors from current bevy master

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ fn setup(
     asset_server: Res<AssetServer>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
-    let icon = asset_server.load("assets/icon.png").unwrap();
+    let icon = asset_server.load("icon.png");
     commands
         .spawn(SpriteComponents {
             material: materials.add(icon.into()),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -27,9 +27,9 @@ fn setup(
     asset_server: Res<AssetServer>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
-    let icon = asset_server.load("assets/icon.png").unwrap();
-    let plat = asset_server.load("assets/platform.png").unwrap();
-    let square = asset_server.load("assets/square.png").unwrap();
+    let icon = asset_server.load("icon.png");
+    let plat = asset_server.load("platform.png");
+    let square = asset_server.load("square.png");
     let mut anchor = None;
     let mut target = None;
     commands
@@ -51,7 +51,7 @@ fn setup(
         })
         .for_current_entity(|e| anchor = Some(e))
         .spawn(SpriteComponents {
-            material: materials.add(plat.into()),
+            material: materials.add(plat.clone_weak().into()),
             ..Default::default()
         })
         .with(
@@ -63,7 +63,7 @@ fn setup(
             parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
         })
         .spawn(SpriteComponents {
-            material: materials.add(plat.into()),
+            material: materials.add(plat.clone_weak().into()),
             ..Default::default()
         })
         .with(
@@ -76,7 +76,7 @@ fn setup(
             parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
         })
         .spawn(SpriteComponents {
-            material: materials.add(plat.into()),
+            material: materials.add(plat.clone_weak().into()),
             ..Default::default()
         })
         .with(
@@ -88,7 +88,7 @@ fn setup(
             parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
         })
         .spawn(SpriteComponents {
-            material: materials.add(plat.into()),
+            material: materials.add(plat.clone_weak().into()),
             ..Default::default()
         })
         .with(
@@ -100,7 +100,7 @@ fn setup(
             parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
         })
         .spawn(SpriteComponents {
-            material: materials.add(plat.into()),
+            material: materials.add(plat.clone_weak().into()),
             ..Default::default()
         })
         .with(
@@ -124,7 +124,7 @@ fn setup(
             parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
         })
         .spawn(SpriteComponents {
-            material: materials.add(square.into()),
+            material: materials.add(square.clone_weak().into()),
             ..Default::default()
         })
         .with(

--- a/examples/simple3d.rs
+++ b/examples/simple3d.rs
@@ -48,17 +48,16 @@ fn setup(
         })
         .spawn((Transform::identity(), GlobalTransform::identity()))
         .with_children(|parent| {
+            let mut transform = Transform::from_translation(Vec3::new(0.0, 8.0, 8.0));
+            transform.rotation = Quat::from_rotation_x(-45.0_f32.to_radians());
             parent.spawn(Camera3dComponents {
-                transform: Transform::from_translation_rotation(
-                    Vec3::new(0.0, 8.0, 8.0),
-                    Quat::from_rotation_x(-45.0_f32.to_radians()),
-                ),
+                transform,
                 ..Default::default()
             });
         })
         .for_current_entity(|e| camera = Some(e))
         .spawn(PbrComponents {
-            mesh: cube,
+            mesh: cube.clone_weak(),
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
             ..Default::default()
         })
@@ -75,7 +74,7 @@ fn setup(
         })
         .for_current_entity(|e| anchor = Some(e))
         .spawn(PbrComponents {
-            mesh: smallcube,
+            mesh: smallcube.clone_weak(),
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
             ..Default::default()
         })
@@ -105,7 +104,7 @@ fn setup(
             parent.spawn((Shape::from(Size3::new(1.0, 1.0, 1.0)),));
         })
         .spawn(PbrComponents {
-            mesh: bigcube,
+            mesh: bigcube.clone_weak(),
             material: materials.add(Color::rgb(0.2, 0.8, 0.2).into()),
             ..Default::default()
         })
@@ -221,8 +220,8 @@ fn character_system(
 
         let pitch = rotation.0;
         if let Ok(mut transform) = camera.get_mut::<Transform>(controller.camera) {
-            transform.set_translation(body.position);
-            transform.set_rotation(Quat::from_rotation_y(pitch));
+            transform.translation = body.position;
+            transform.rotation = Quat::from_rotation_y(pitch);
         }
     }
 }

--- a/examples/top_down.rs
+++ b/examples/top_down.rs
@@ -21,8 +21,8 @@ fn setup(
     asset_server: Res<AssetServer>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
-    let icon = asset_server.load("assets/icon.png").unwrap();
-    let square = asset_server.load("assets/square.png").unwrap();
+    let icon = asset_server.load("icon.png");
+    let square = asset_server.load("square.png");
     commands
         .spawn(Camera2dComponents::default())
         .spawn(SpriteComponents {
@@ -37,7 +37,7 @@ fn setup(
         )
         .with(CharacterController::default())
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size::new(28.0, 28.0)),));
+            parent.spawn((Shape::from(Size2::new(28.0, 28.0)),));
         })
         .spawn(SpriteComponents {
             material: materials.add(square.into()),
@@ -49,7 +49,7 @@ fn setup(
                 .with_position(Vec2::new(0.0, 60.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size::new(20.0, 20.0)),));
+            parent.spawn((Shape::from(Size2::new(20.0, 20.0)),));
         });
 }
 
@@ -77,16 +77,16 @@ fn character_system(
             body.rotation -= 0.1;
         }
         if input.pressed(KeyCode::W) {
-            body.apply_impulse(Vec2::new(0.0, 5.0));
+            body.apply_linear_impulse(Vec2::new(0.0, 5.0));
         }
         if input.pressed(KeyCode::S) {
-            body.apply_impulse(Vec2::new(0.0, -5.0));
+            body.apply_linear_impulse(Vec2::new(0.0, -5.0));
         }
         if input.pressed(KeyCode::A) {
-            body.apply_impulse(Vec2::new(-5.0, 0.0));
+            body.apply_linear_impulse(Vec2::new(-5.0, 0.0));
         }
         if input.pressed(KeyCode::D) {
-            body.apply_impulse(Vec2::new(5.0, 0.0));
+            body.apply_linear_impulse(Vec2::new(5.0, 0.0));
         }
     }
 }

--- a/src/dim2.rs
+++ b/src/dim2.rs
@@ -1044,7 +1044,7 @@ fn solve_system(
 
                     let d = -manifold.normal * manifold.penetration;
                     let v = a.linvel * delta_time;
-                    if v.sign() == d.sign() {
+                    if v.signum() == d.signum() {
                         // nothing
                     } else {
                         a.linvel *= Vec2::new(manifold.normal.y().abs(), manifold.normal.x().abs());
@@ -1072,7 +1072,7 @@ fn solve_system(
                     if solve {
                         let d = -manifold.normal * manifold.penetration;
                         let v = a.linvel * delta_time;
-                        if v.sign() == d.sign() {
+                        if v.signum() == d.signum() {
                             // nothing
                         } else {
                             a.linvel *=
@@ -1094,7 +1094,7 @@ fn solve_system(
 
                     let d = manifold.normal * manifold.penetration;
                     let v = b.linvel * delta_time;
-                    if v.sign() == d.sign() {
+                    if v.signum() == d.signum() {
                         // nothing
                     } else {
                         b.linvel *= Vec2::new(manifold.normal.y().abs(), manifold.normal.x().abs());
@@ -1122,7 +1122,7 @@ fn solve_system(
                     if solve {
                         let d = manifold.normal * manifold.penetration;
                         let v = b.linvel * delta_time;
-                        if v.sign() == d.sign() {
+                        if v.signum() == d.signum() {
                             // nothing
                         } else {
                             b.linvel *=
@@ -1364,30 +1364,30 @@ pub fn sync_transform_system(
                 let x = body.position.x();
                 let y = body.position.y();
                 let z = 0.0;
-                transform.set_translation(Vec3::new(x, y, z));
+                transform.translation = Vec3::new(x, y, z);
             }
             TranslationMode::AxesXZ => {
                 let x = body.position.x();
                 let y = 0.0;
                 let z = body.position.y();
-                transform.set_translation(Vec3::new(x, y, z));
+                transform.translation = Vec3::new(x, y, z);
             }
             TranslationMode::AxesYZ => {
                 let x = 0.0;
                 let y = body.position.x();
                 let z = body.position.y();
-                transform.set_translation(Vec3::new(x, y, z));
+                transform.translation = Vec3::new(x, y, z);
             }
         }
         match *rotation_mode {
             RotationMode::AxisX => {
-                transform.set_rotation(Quat::from_rotation_x(body.rotation));
+                transform.rotation = Quat::from_rotation_x(body.rotation);
             }
             RotationMode::AxisY => {
-                transform.set_rotation(Quat::from_rotation_y(body.rotation));
+                transform.rotation = Quat::from_rotation_y(body.rotation);
             }
             RotationMode::AxisZ => {
-                transform.set_rotation(Quat::from_rotation_z(body.rotation));
+                transform.rotation = Quat::from_rotation_z(body.rotation);
             }
         }
     }

--- a/src/dim3/collision.rs
+++ b/src/dim3/collision.rs
@@ -14,7 +14,7 @@ trait Mult {
 
 impl Mult for Transform {
     fn mult(&self, v: Vec3) -> Vec3 {
-        self.rotation().conjugate() * (v - self.translation())
+        self.rotation.conjugate() * (v - self.translation)
     }
 }
 
@@ -110,7 +110,7 @@ fn track_edge_axis(n: u32, mut s: f32, smax: f32, normal: Vec3) -> TrackEdgeAxis
         return TrackEdgeAxis::None;
     }
 
-    let l = normal.length_reciprocal();
+    let l = normal.length_recip();
     s *= l;
 
     if s > smax {
@@ -124,76 +124,55 @@ fn track_edge_axis(n: u32, mut s: f32, smax: f32, normal: Vec3) -> TrackEdgeAxis
 }
 
 fn compute_incident_face(itx: Transform, e: Vec3, n: Vec3) -> [Vec3; 4] {
-    let n = -itx.rotation().mult(n);
+    let n = -itx.rotation.mult(n);
     let absn = n.abs();
-
+    let itx_matrix = itx.compute_matrix();
     if absn.x() > absn.y() && absn.x() > absn.z() {
         if n.x() > 0.0 {
             [
-                itx.value()
-                    .transform_point3(Vec3::new(e.x(), e.y(), -e.z())),
-                itx.value().transform_point3(Vec3::new(e.x(), e.y(), e.z())),
-                itx.value()
-                    .transform_point3(Vec3::new(e.x(), -e.y(), e.z())),
-                itx.value()
-                    .transform_point3(Vec3::new(e.x(), -e.y(), -e.z())),
+                itx_matrix.transform_point3(Vec3::new(e.x(), e.y(), -e.z())),
+                itx_matrix.transform_point3(Vec3::new(e.x(), e.y(), e.z())),
+                itx_matrix.transform_point3(Vec3::new(e.x(), -e.y(), e.z())),
+                itx_matrix.transform_point3(Vec3::new(e.x(), -e.y(), -e.z())),
             ]
         } else {
             [
-                itx.value()
-                    .transform_point3(Vec3::new(-e.x(), -e.y(), e.z())),
-                itx.value()
-                    .transform_point3(Vec3::new(-e.x(), e.y(), e.z())),
-                itx.value()
-                    .transform_point3(Vec3::new(-e.x(), e.y(), -e.z())),
-                itx.value()
-                    .transform_point3(Vec3::new(-e.x(), -e.y(), -e.z())),
+                itx_matrix.transform_point3(Vec3::new(-e.x(), -e.y(), e.z())),
+                itx_matrix.transform_point3(Vec3::new(-e.x(), e.y(), e.z())),
+                itx_matrix.transform_point3(Vec3::new(-e.x(), e.y(), -e.z())),
+                itx_matrix.transform_point3(Vec3::new(-e.x(), -e.y(), -e.z())),
             ]
         }
     } else if absn.y() > absn.x() && absn.y() > absn.z() {
         if n.y() > 0.0 {
             [
-                itx.value()
-                    .transform_point3(Vec3::new(-e.x(), e.y(), e.z())),
-                itx.value().transform_point3(Vec3::new(e.x(), e.y(), e.z())),
-                itx.value()
-                    .transform_point3(Vec3::new(e.x(), e.y(), -e.z())),
-                itx.value()
-                    .transform_point3(Vec3::new(-e.x(), e.y(), -e.z())),
+                itx_matrix.transform_point3(Vec3::new(-e.x(), e.y(), e.z())),
+                itx_matrix.transform_point3(Vec3::new(e.x(), e.y(), e.z())),
+                itx_matrix.transform_point3(Vec3::new(e.x(), e.y(), -e.z())),
+                itx_matrix.transform_point3(Vec3::new(-e.x(), e.y(), -e.z())),
             ]
         } else {
             [
-                itx.value()
-                    .transform_point3(Vec3::new(e.x(), -e.y(), e.z())),
-                itx.value()
-                    .transform_point3(Vec3::new(-e.x(), -e.y(), e.z())),
-                itx.value()
-                    .transform_point3(Vec3::new(-e.x(), -e.y(), -e.z())),
-                itx.value()
-                    .transform_point3(Vec3::new(e.x(), -e.y(), -e.z())),
+                itx_matrix.transform_point3(Vec3::new(e.x(), -e.y(), e.z())),
+                itx_matrix.transform_point3(Vec3::new(-e.x(), -e.y(), e.z())),
+                itx_matrix.transform_point3(Vec3::new(-e.x(), -e.y(), -e.z())),
+                itx_matrix.transform_point3(Vec3::new(e.x(), -e.y(), -e.z())),
             ]
         }
     } else {
         if n.z() > 0.0 {
             [
-                itx.value()
-                    .transform_point3(Vec3::new(-e.x(), e.y(), e.z())),
-                itx.value()
-                    .transform_point3(Vec3::new(-e.x(), -e.y(), e.z())),
-                itx.value()
-                    .transform_point3(Vec3::new(e.x(), -e.y(), e.z())),
-                itx.value().transform_point3(Vec3::new(e.x(), e.y(), e.z())),
+                itx_matrix.transform_point3(Vec3::new(-e.x(), e.y(), e.z())),
+                itx_matrix.transform_point3(Vec3::new(-e.x(), -e.y(), e.z())),
+                itx_matrix.transform_point3(Vec3::new(e.x(), -e.y(), e.z())),
+                itx_matrix.transform_point3(Vec3::new(e.x(), e.y(), e.z())),
             ]
         } else {
             [
-                itx.value()
-                    .transform_point3(Vec3::new(e.x(), -e.y(), -e.z())),
-                itx.value()
-                    .transform_point3(Vec3::new(-e.x(), -e.y(), -e.z())),
-                itx.value()
-                    .transform_point3(Vec3::new(-e.x(), e.y(), -e.z())),
-                itx.value()
-                    .transform_point3(Vec3::new(e.x(), e.y(), -e.z())),
+                itx_matrix.transform_point3(Vec3::new(e.x(), -e.y(), -e.z())),
+                itx_matrix.transform_point3(Vec3::new(-e.x(), -e.y(), -e.z())),
+                itx_matrix.transform_point3(Vec3::new(-e.x(), e.y(), -e.z())),
+                itx_matrix.transform_point3(Vec3::new(e.x(), e.y(), -e.z())),
             ]
         }
     }
@@ -205,13 +184,13 @@ struct RefEb {
 }
 
 fn compute_reference_edges_and_basis(er: Vec3, rtx: Transform, n: Vec3, mut axis: u32) -> RefEb {
-    let n = rtx.rotation().mult(n);
+    let n = rtx.rotation.mult(n);
 
     if axis >= 3 {
         axis -= 3;
     }
 
-    let rot = rtx.value().truncate();
+    let rot = rtx.compute_matrix().truncate();
     match axis {
         0 => {
             if n.x() > 0.0 {
@@ -361,7 +340,7 @@ fn edges_contact(pa: Vec3, qa: Vec3, pb: Vec3, qb: Vec3) -> [Vec3; 2] {
 }
 
 fn support_edge(tx: Transform, e: Vec3, n: Vec3) -> [Vec3; 2] {
-    let n = tx.rotation().mult(n);
+    let n = tx.rotation.mult(n);
     let absn = n.abs();
     let a;
     let b;
@@ -384,14 +363,14 @@ fn support_edge(tx: Transform, e: Vec3, n: Vec3) -> [Vec3; 2] {
         }
     }
 
-    let sign = n.sign();
+    let sign = n.signum();
 
     let a = a * sign;
     let b = b * sign;
 
     [
-        tx.value().transform_point3(a),
-        tx.value().transform_point3(b),
+        tx.compute_matrix().transform_point3(a),
+        tx.compute_matrix().transform_point3(b),
     ]
 }
 
@@ -400,15 +379,16 @@ pub fn box_to_box(a: &Obb, b: &Obb) -> Option<Manifold> {
     let mut btx = b.transform;
     let al = a.local;
     let bl = b.local;
-    *atx.value_mut() = *atx.value() * *al.value();
-    *btx.value_mut() = *btx.value() * *bl.value();
+
+    atx = Transform::from_matrix(atx.compute_matrix() * al.compute_matrix());
+    btx = Transform::from_matrix(btx.compute_matrix() * bl.compute_matrix());
 
     let ea = a.extent;
     let eb = b.extent;
 
     // conjugate is the same as inverse for unit squaternions,
     // inverse is the same as transpose for rotation matrices
-    let c = Mat3::from_quat(atx.rotation().conjugate() * btx.rotation());
+    let c = Mat3::from_quat(atx.rotation.conjugate() * btx.rotation);
     let ca = c.to_cols_array_2d();
 
     let mut absc = [[0.0; 3]; 3];
@@ -428,7 +408,7 @@ pub fn box_to_box(a: &Obb, b: &Obb) -> Option<Manifold> {
     let absca = absc;
     let absc = Mat3::from_cols_array_2d(&absca);
 
-    let t = atx.rotation().mult(btx.translation() - atx.translation());
+    let t = atx.rotation.mult(btx.translation - atx.translation);
 
     let mut s;
     let mut amax = f32::MIN;
@@ -441,7 +421,7 @@ pub fn box_to_box(a: &Obb, b: &Obb) -> Option<Manifold> {
     let mut nb = Vec3::zero();
     let mut ne = Vec3::zero();
 
-    let atxr = atx.value().truncate();
+    let atxr = atx.compute_matrix().truncate();
 
     s = t.x().abs() - (ea.x() + absc.column0().dot(eb));
     match track_face_axis(0, s, amax, atxr.row0()) {
@@ -476,7 +456,7 @@ pub fn box_to_box(a: &Obb, b: &Obb) -> Option<Manifold> {
         _ => {}
     }
 
-    let btxr = btx.value().truncate();
+    let btxr = btx.compute_matrix().truncate();
 
     s = t.dot(c.row0()).abs() - (eb.x() + absc.row0().dot(ea));
     match track_face_axis(3, s, bmax, btxr.row0()) {
@@ -663,7 +643,7 @@ pub fn box_to_box(a: &Obb, b: &Obb) -> Option<Manifold> {
         n = na;
     }
 
-    if n.dot(btx.translation() - atx.translation()) < 0.0 {
+    if n.dot(btx.translation - atx.translation) < 0.0 {
         n = -n;
     }
 
@@ -698,7 +678,7 @@ pub fn box_to_box(a: &Obb, b: &Obb) -> Option<Manifold> {
         let basis = refeb.basis;
         let e = refeb.e;
 
-        let clip = clip(rtx.translation(), e, basis, incident);
+        let clip = clip(rtx.translation, e, basis, incident);
         let out = clip.out;
 
         if out.len() > 0 {
@@ -723,9 +703,9 @@ pub fn box_to_box(a: &Obb, b: &Obb) -> Option<Manifold> {
             None
         }
     } else {
-        let mut n = atx.rotation() * n;
+        let mut n = atx.rotation * n;
 
-        if n.dot(btx.translation() - atx.translation()) < 0.0 {
+        if n.dot(btx.translation - atx.translation) < 0.0 {
             n = -n;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!     asset_server: Res<AssetServer>,
 //!     mut materials: ResMut<Assets<ColorMaterial>>,
 //! ) {
-//!     let icon = asset_server.load("assets/icon.png").unwrap();
+//!     let icon = asset_server.load("assets/icon.png");
 //!     commands
 //!         .spawn(SpriteComponents {
 //!             material: materials.add(icon.into()),
@@ -68,7 +68,7 @@
 //! #     asset_server: Res<AssetServer>,
 //! #     mut materials: ResMut<Assets<ColorMaterial>>,
 //! # ) {
-//! #     let icon = asset_server.load("assets/icon.png").unwrap();
+//! #     let icon = asset_server.load("assets/icon.png");
 //! #     commands
 //! #         .spawn(SpriteComponents {
 //! #             material: materials.add(icon.into()),
@@ -81,7 +81,7 @@
 //! #                 .with_terminal(Vec2::new(500.0, 1000.0)),
 //! #         )
 //!         .with_children(|parent| {
-//!             parent.spawn((Shape::from(Size::new(28.0, 28.0)),));
+//!             parent.spawn((Shape::from(Size2::new(28.0, 28.0)),));
 //!         });
 //! # }
 //! ```


### PR DESCRIPTION
There have been a few changes to the bevy master branch (still under version 0.2.1) that caused some compile errors in physme.

This includes commit [5acebed73184175bf089aec5516782b094d08199](https://github.com/bevyengine/bevy/commit/5acebed73184175bf089aec5516782b094d08199) that changed the struct Transform to no longer consist of the transformation matrix but rather the three components. 
I replaced the usages of the previous functions.

Furthermore in commit [c32e637384936d973918fb59d1c37c0a4f4f41f7](https://github.com/bevyengine/bevy/commit/c32e637384936d973918fb59d1c37c0a4f4f41f7) the asset server was changed to by default use the "assets" path as a default. 
This caused the examples to fail to load the assets. Also he load function no longer return an Option.

`cargo fmt --all -- --check` runs successfully.
The tests and the examples also execute successfully.