### PR TITLE
Make Shape fields public

### DIFF
--- a/src/dim2.rs
+++ b/src/dim2.rs
@@ -226,8 +226,8 @@ impl Size2 {
 /// Contains a rotation/translation offset and a size.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Properties)]
 pub struct Shape {
-    offset: Vec2,
-    size: Size2,
+    pub offset: Vec2,
+    pub size: Size2,
 }
 
 impl Shape {


### PR DESCRIPTION
The fields of `Shape` weren't previously public, now they're accessable