### PR TITLE
Update to latest (unpublished) bevy version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ serde = "1.0"
 [dependencies.bevy]
 version = "0.3"
 git = "https://github.com/bevyengine/bevy.git"
-branch = "master"
+commit = "01ba7c44255059f833c2b90d3d6b7ac7e9c025ca"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ serde = "1.0"
 [dependencies.bevy]
 version = "0.3"
 git = "https://github.com/bevyengine/bevy.git"
-commit = "01ba7c44255059f833c2b90d3d6b7ac7e9c025ca"
+rev = "01ba7c44255059f833c2b90d3d6b7ac7e9c025ca"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -46,7 +46,7 @@ fn setup(
         )
         .with(CharacterController::default())
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(28.0, 28.0)), ));
+            parent.spawn((Shape::from(Size2::new(28.0, 28.0)),));
         })
         .for_current_entity(|e| anchor = Some(e))
         .spawn(SpriteBundle {
@@ -59,7 +59,7 @@ fn setup(
                 .with_position(Vec2::new(0.0, -100.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(120.0, 20.0)), ));
+            parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
         })
         .spawn(SpriteBundle {
             material: materials.add(plat.clone_weak().into()),
@@ -72,7 +72,7 @@ fn setup(
                 .with_rotation(10.0_f32.to_radians()),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(120.0, 20.0)), ));
+            parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
         })
         .spawn(SpriteBundle {
             material: materials.add(plat.clone_weak().into()),
@@ -84,7 +84,7 @@ fn setup(
                 .with_position(Vec2::new(-120.0, -90.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(120.0, 20.0)), ));
+            parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
         })
         .spawn(SpriteBundle {
             material: materials.add(plat.clone_weak().into()),
@@ -96,7 +96,7 @@ fn setup(
                 .with_position(Vec2::new(360.0, -50.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(120.0, 20.0)), ));
+            parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
         })
         .spawn(SpriteBundle {
             material: materials.add(plat.clone_weak().into()),
@@ -108,7 +108,7 @@ fn setup(
                 .with_position(Vec2::new(120.0, -10.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(120.0, 20.0)), ));
+            parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
         })
         .spawn(SpriteBundle {
             material: materials.add(plat.into()),
@@ -120,7 +120,7 @@ fn setup(
                 .with_position(Vec2::new(-120.0, 20.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(120.0, 20.0)), ));
+            parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
         })
         .spawn(SpriteBundle {
             material: materials.add(square.clone_weak().into()),
@@ -132,7 +132,7 @@ fn setup(
                 .with_position(Vec2::new(30.0, 60.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(20.0, 20.0)), ));
+            parent.spawn((Shape::from(Size2::new(20.0, 20.0)),));
         })
         .spawn(SpriteBundle {
             material: materials.add(square.into()),
@@ -144,7 +144,7 @@ fn setup(
                 .with_position(Vec2::new(100.0, 100.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(20.0, 20.0)), ));
+            parent.spawn((Shape::from(Size2::new(20.0, 20.0)),));
         })
         .for_current_entity(|e| target = Some(e))
         .spawn((
@@ -166,13 +166,13 @@ fn character_system(
     for manifold in state.reader.iter(&manifolds) {
         if manifold.normal.y() < 0.0 {
             if let Ok(mut controller) =
-            query.get_component_mut::<CharacterController>(manifold.body1)
+                query.get_component_mut::<CharacterController>(manifold.body1)
             {
                 controller.on_ground = true;
             }
         } else if manifold.normal.y() > 0.0 {
             if let Ok(mut controller) =
-            query.get_component_mut::<CharacterController>(manifold.body2)
+                query.get_component_mut::<CharacterController>(manifold.body2)
             {
                 controller.on_ground = true;
             }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -17,7 +17,6 @@ fn main() {
         .add_resource(GlobalStep(15.0))
         .add_resource(GlobalUp(Vec2::new(0.0, 1.0)))
         .add_startup_system(setup.system());
-    let character_system = CharacterControllerSystem::default().system(builder.resources_mut());
     builder.add_system(character_system);
     builder.run();
 }
@@ -33,8 +32,8 @@ fn setup(
     let mut anchor = None;
     let mut target = None;
     commands
-        .spawn(Camera2dComponents::default())
-        .spawn(SpriteComponents {
+        .spawn(Camera2dBundle::default())
+        .spawn(SpriteBundle {
             material: materials.add(icon.into()),
             ..Default::default()
         })
@@ -47,10 +46,10 @@ fn setup(
         )
         .with(CharacterController::default())
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(28.0, 28.0)),));
+            parent.spawn((Shape::from(Size2::new(28.0, 28.0)), ));
         })
         .for_current_entity(|e| anchor = Some(e))
-        .spawn(SpriteComponents {
+        .spawn(SpriteBundle {
             material: materials.add(plat.clone_weak().into()),
             ..Default::default()
         })
@@ -60,9 +59,9 @@ fn setup(
                 .with_position(Vec2::new(0.0, -100.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
+            parent.spawn((Shape::from(Size2::new(120.0, 20.0)), ));
         })
-        .spawn(SpriteComponents {
+        .spawn(SpriteBundle {
             material: materials.add(plat.clone_weak().into()),
             ..Default::default()
         })
@@ -73,9 +72,9 @@ fn setup(
                 .with_rotation(10.0_f32.to_radians()),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
+            parent.spawn((Shape::from(Size2::new(120.0, 20.0)), ));
         })
-        .spawn(SpriteComponents {
+        .spawn(SpriteBundle {
             material: materials.add(plat.clone_weak().into()),
             ..Default::default()
         })
@@ -85,9 +84,9 @@ fn setup(
                 .with_position(Vec2::new(-120.0, -90.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
+            parent.spawn((Shape::from(Size2::new(120.0, 20.0)), ));
         })
-        .spawn(SpriteComponents {
+        .spawn(SpriteBundle {
             material: materials.add(plat.clone_weak().into()),
             ..Default::default()
         })
@@ -97,9 +96,9 @@ fn setup(
                 .with_position(Vec2::new(360.0, -50.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
+            parent.spawn((Shape::from(Size2::new(120.0, 20.0)), ));
         })
-        .spawn(SpriteComponents {
+        .spawn(SpriteBundle {
             material: materials.add(plat.clone_weak().into()),
             ..Default::default()
         })
@@ -109,9 +108,9 @@ fn setup(
                 .with_position(Vec2::new(120.0, -10.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
+            parent.spawn((Shape::from(Size2::new(120.0, 20.0)), ));
         })
-        .spawn(SpriteComponents {
+        .spawn(SpriteBundle {
             material: materials.add(plat.into()),
             ..Default::default()
         })
@@ -121,9 +120,9 @@ fn setup(
                 .with_position(Vec2::new(-120.0, 20.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(120.0, 20.0)),));
+            parent.spawn((Shape::from(Size2::new(120.0, 20.0)), ));
         })
-        .spawn(SpriteComponents {
+        .spawn(SpriteBundle {
             material: materials.add(square.clone_weak().into()),
             ..Default::default()
         })
@@ -133,9 +132,9 @@ fn setup(
                 .with_position(Vec2::new(30.0, 60.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(20.0, 20.0)),));
+            parent.spawn((Shape::from(Size2::new(20.0, 20.0)), ));
         })
-        .spawn(SpriteComponents {
+        .spawn(SpriteBundle {
             material: materials.add(square.into()),
             ..Default::default()
         })
@@ -145,7 +144,7 @@ fn setup(
                 .with_position(Vec2::new(100.0, 100.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(20.0, 20.0)),));
+            parent.spawn((Shape::from(Size2::new(20.0, 20.0)), ));
         })
         .for_current_entity(|e| target = Some(e))
         .spawn((
@@ -158,14 +157,6 @@ pub struct CharacterControllerSystem {
     reader: EventReader<Manifold>,
 }
 
-impl CharacterControllerSystem {
-    pub fn system(self, res: &mut Resources) -> Box<dyn System> {
-        let system = character_system.system();
-        res.insert_local(system.id(), self);
-        system
-    }
-}
-
 fn character_system(
     mut state: Local<CharacterControllerSystem>,
     input: Res<Input<KeyCode>>,
@@ -175,13 +166,13 @@ fn character_system(
     for manifold in state.reader.iter(&manifolds) {
         if manifold.normal.y() < 0.0 {
             if let Ok(mut controller) =
-                query.get_component_mut::<CharacterController>(manifold.body1)
+            query.get_component_mut::<CharacterController>(manifold.body1)
             {
                 controller.on_ground = true;
             }
         } else if manifold.normal.y() > 0.0 {
             if let Ok(mut controller) =
-                query.get_component_mut::<CharacterController>(manifold.body2)
+            query.get_component_mut::<CharacterController>(manifold.body2)
             {
                 controller.on_ground = true;
             }

--- a/examples/simple3d.rs
+++ b/examples/simple3d.rs
@@ -25,7 +25,6 @@ fn main() {
         .add_resource(GlobalFriction(0.90))
         .add_resource(GlobalStep(0.5))
         .add_startup_system(setup.system());
-    let character_system = CharacterControllerSystem::default().system(builder.resources_mut());
     builder.add_system(character_system);
     builder.run();
 }
@@ -42,7 +41,7 @@ fn setup(
     let mut anchor = None;
     let mut target = None;
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(0.0, 5.0, 5.0)),
             ..Default::default()
         })
@@ -50,13 +49,13 @@ fn setup(
         .with_children(|parent| {
             let mut transform = Transform::from_translation(Vec3::new(0.0, 8.0, 8.0));
             transform.rotation = Quat::from_rotation_x(-45.0_f32.to_radians());
-            parent.spawn(Camera3dComponents {
+            parent.spawn(Camera3dBundle {
                 transform,
                 ..Default::default()
             });
         })
         .for_current_entity(|e| camera = Some(e))
-        .spawn(PbrComponents {
+        .spawn(PbrBundle {
             mesh: cube.clone_weak(),
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
             ..Default::default()
@@ -70,10 +69,10 @@ fn setup(
         .with(UpRotation::default())
         .with(CharacterController::new(camera.unwrap()))
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size3::new(1.0, 1.0, 1.0)),));
+            parent.spawn((Shape::from(Size3::new(1.0, 1.0, 1.0)), ));
         })
         .for_current_entity(|e| anchor = Some(e))
-        .spawn(PbrComponents {
+        .spawn(PbrBundle {
             mesh: smallcube.clone_weak(),
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
             ..Default::default()
@@ -84,13 +83,13 @@ fn setup(
                 .with_position(Vec3::new(10.0, 10.0, 10.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size3::new(0.2, 0.2, 0.2)),));
+            parent.spawn((Shape::from(Size3::new(0.2, 0.2, 0.2)), ));
         })
         .for_current_entity(|e| target = Some(e))
         .spawn((SpringJoint::new(anchor.unwrap(), target.unwrap())
-            .with_rigidness(0.5)
-            .with_offset(Vec3::new(2.0, 2.0, 0.0)),))
-        .spawn(PbrComponents {
+                    .with_rigidness(0.5)
+                    .with_offset(Vec3::new(2.0, 2.0, 0.0)), ))
+        .spawn(PbrBundle {
             mesh: cube,
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
             ..Default::default()
@@ -101,9 +100,9 @@ fn setup(
                 .with_position(Vec3::new(5.0, 5.0, 5.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size3::new(1.0, 1.0, 1.0)),));
+            parent.spawn((Shape::from(Size3::new(1.0, 1.0, 1.0)), ));
         })
-        .spawn(PbrComponents {
+        .spawn(PbrBundle {
             mesh: bigcube.clone_weak(),
             material: materials.add(Color::rgb(0.2, 0.8, 0.2).into()),
             ..Default::default()
@@ -114,9 +113,9 @@ fn setup(
                 .with_position(Vec3::new(0.0, -8.0, 0.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size3::new(16.0, 16.0, 16.0)),));
+            parent.spawn((Shape::from(Size3::new(16.0, 16.0, 16.0)), ));
         })
-        .spawn(PbrComponents {
+        .spawn(PbrBundle {
             mesh: bigcube,
             material: materials.add(Color::rgb(0.5, 0.5, 0.5).into()),
             ..Default::default()
@@ -128,9 +127,9 @@ fn setup(
                 .with_rotation(Quat::from_rotation_x(10.0_f32.to_radians())),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size3::new(16.0, 16.0, 16.0)),));
+            parent.spawn((Shape::from(Size3::new(16.0, 16.0, 16.0)), ));
         })
-        .spawn(PbrComponents {
+        .spawn(PbrBundle {
             mesh: smallcube,
             material: materials.add(Color::rgb(0.2, 0.8, 0.2).into()),
             ..Default::default()
@@ -141,21 +140,13 @@ fn setup(
                 .with_position(Vec3::new(-3.0, 0.0, -3.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size3::new(0.4, 0.4, 0.4)),));
+            parent.spawn((Shape::from(Size3::new(0.4, 0.4, 0.4)), ));
         });
 }
 
 #[derive(Default)]
 pub struct CharacterControllerSystem {
     reader: EventReader<Manifold>,
-}
-
-impl CharacterControllerSystem {
-    pub fn system(self, res: &mut Resources) -> Box<dyn System> {
-        let system = character_system.system();
-        res.insert_local(system.id(), self);
-        system
-    }
 }
 
 fn character_system(
@@ -175,13 +166,13 @@ fn character_system(
         let angle2 = dot.acos();
         if angle >= 0.0 && angle < ang_tol.0 {
             if let Ok(mut controller) =
-                query.get_component_mut::<CharacterController>(manifold.body1)
+            query.get_component_mut::<CharacterController>(manifold.body1)
             {
                 controller.on_ground = true;
             }
         } else if angle2 >= 0.0 && angle2 < ang_tol.0 {
             if let Ok(mut controller) =
-                query.get_component_mut::<CharacterController>(manifold.body2)
+            query.get_component_mut::<CharacterController>(manifold.body2)
             {
                 controller.on_ground = true;
             }

--- a/examples/simple3d.rs
+++ b/examples/simple3d.rs
@@ -69,7 +69,7 @@ fn setup(
         .with(UpRotation::default())
         .with(CharacterController::new(camera.unwrap()))
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size3::new(1.0, 1.0, 1.0)), ));
+            parent.spawn((Shape::from(Size3::new(1.0, 1.0, 1.0)),));
         })
         .for_current_entity(|e| anchor = Some(e))
         .spawn(PbrBundle {
@@ -83,12 +83,12 @@ fn setup(
                 .with_position(Vec3::new(10.0, 10.0, 10.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size3::new(0.2, 0.2, 0.2)), ));
+            parent.spawn((Shape::from(Size3::new(0.2, 0.2, 0.2)),));
         })
         .for_current_entity(|e| target = Some(e))
         .spawn((SpringJoint::new(anchor.unwrap(), target.unwrap())
-                    .with_rigidness(0.5)
-                    .with_offset(Vec3::new(2.0, 2.0, 0.0)), ))
+            .with_rigidness(0.5)
+            .with_offset(Vec3::new(2.0, 2.0, 0.0)),))
         .spawn(PbrBundle {
             mesh: cube,
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
@@ -100,7 +100,7 @@ fn setup(
                 .with_position(Vec3::new(5.0, 5.0, 5.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size3::new(1.0, 1.0, 1.0)), ));
+            parent.spawn((Shape::from(Size3::new(1.0, 1.0, 1.0)),));
         })
         .spawn(PbrBundle {
             mesh: bigcube.clone_weak(),
@@ -113,7 +113,7 @@ fn setup(
                 .with_position(Vec3::new(0.0, -8.0, 0.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size3::new(16.0, 16.0, 16.0)), ));
+            parent.spawn((Shape::from(Size3::new(16.0, 16.0, 16.0)),));
         })
         .spawn(PbrBundle {
             mesh: bigcube,
@@ -127,7 +127,7 @@ fn setup(
                 .with_rotation(Quat::from_rotation_x(10.0_f32.to_radians())),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size3::new(16.0, 16.0, 16.0)), ));
+            parent.spawn((Shape::from(Size3::new(16.0, 16.0, 16.0)),));
         })
         .spawn(PbrBundle {
             mesh: smallcube,
@@ -140,7 +140,7 @@ fn setup(
                 .with_position(Vec3::new(-3.0, 0.0, -3.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size3::new(0.4, 0.4, 0.4)), ));
+            parent.spawn((Shape::from(Size3::new(0.4, 0.4, 0.4)),));
         });
 }
 
@@ -166,13 +166,13 @@ fn character_system(
         let angle2 = dot.acos();
         if angle >= 0.0 && angle < ang_tol.0 {
             if let Ok(mut controller) =
-            query.get_component_mut::<CharacterController>(manifold.body1)
+                query.get_component_mut::<CharacterController>(manifold.body1)
             {
                 controller.on_ground = true;
             }
         } else if angle2 >= 0.0 && angle2 < ang_tol.0 {
             if let Ok(mut controller) =
-            query.get_component_mut::<CharacterController>(manifold.body2)
+                query.get_component_mut::<CharacterController>(manifold.body2)
             {
                 controller.on_ground = true;
             }

--- a/examples/top_down.rs
+++ b/examples/top_down.rs
@@ -11,7 +11,6 @@ fn main() {
         .add_plugin(Physics2dPlugin)
         .add_resource(GlobalFriction(0.90))
         .add_startup_system(setup.system());
-    let character_system = CharacterControllerSystem::default().system(builder.resources_mut());
     builder.add_system(character_system);
     builder.run();
 }
@@ -24,8 +23,8 @@ fn setup(
     let icon = asset_server.load("icon.png");
     let square = asset_server.load("square.png");
     commands
-        .spawn(Camera2dComponents::default())
-        .spawn(SpriteComponents {
+        .spawn(Camera2dBundle::default())
+        .spawn(SpriteBundle {
             material: materials.add(icon.into()),
             ..Default::default()
         })
@@ -37,9 +36,9 @@ fn setup(
         )
         .with(CharacterController::default())
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(28.0, 28.0)),));
+            parent.spawn((Shape::from(Size2::new(28.0, 28.0)), ));
         })
-        .spawn(SpriteComponents {
+        .spawn(SpriteBundle {
             material: materials.add(square.into()),
             ..Default::default()
         })
@@ -49,20 +48,12 @@ fn setup(
                 .with_position(Vec2::new(0.0, 60.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(20.0, 20.0)),));
+            parent.spawn((Shape::from(Size2::new(20.0, 20.0)), ));
         });
 }
 
 #[derive(Default)]
 pub struct CharacterControllerSystem;
-
-impl CharacterControllerSystem {
-    pub fn system(self, res: &mut Resources) -> Box<dyn System> {
-        let system = character_system.system();
-        res.insert_local(system.id(), self);
-        system
-    }
-}
 
 fn character_system(
     input: Res<Input<KeyCode>>,

--- a/examples/top_down.rs
+++ b/examples/top_down.rs
@@ -36,7 +36,7 @@ fn setup(
         )
         .with(CharacterController::default())
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(28.0, 28.0)), ));
+            parent.spawn((Shape::from(Size2::new(28.0, 28.0)),));
         })
         .spawn(SpriteBundle {
             material: materials.add(square.into()),
@@ -48,7 +48,7 @@ fn setup(
                 .with_position(Vec2::new(0.0, 60.0)),
         )
         .with_children(|parent| {
-            parent.spawn((Shape::from(Size2::new(20.0, 20.0)), ));
+            parent.spawn((Shape::from(Size2::new(20.0, 20.0)),));
         });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //! ) {
 //!     let icon = asset_server.load("assets/icon.png");
 //!     commands
-//!         .spawn(SpriteComponents {
+//!         .spawn(SpriteBundle {
 //!             material: materials.add(icon.into()),
 //!             ..Default::default()
 //!         })
@@ -70,7 +70,7 @@
 //! # ) {
 //! #     let icon = asset_server.load("assets/icon.png");
 //! #     commands
-//! #         .spawn(SpriteComponents {
+//! #         .spawn(SpriteBundle {
 //! #             material: materials.add(icon.into()),
 //! #             ..Default::default()
 //! #         })


### PR DESCRIPTION
Hi, 

I wanted to try using this library with the latest (unpublished) version of Bevy.

So, I did two things:

1. Update code so that it compiles and runs using bevy
2. Update `Cargo.toml` so that it explicitly uses a specific commit of `bevy` (namely [01ba7c](https://github.com/bevyengine/bevy/tree/01ba7c44255059f833c2b90d3d6b7ac7e9c025ca))

The second points make it easier to pickup a compatible version of bevy.

Hopefuly you find this changes interesting ;-) 